### PR TITLE
Adiciona passo para juntar PL's de diversos interesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ Além disso, o repositório [`rcongresso`](https://github.com/analytics-ufcg/rco
 ### Passo 1
 Para executá-lo é preciso configurar as variáveis de ambiente por ele utilizadas. Para isto, **crie uma cópia do arquivo .env.sample** e o renomeie para `.env`. Em seguida preencha as variáveis com os valores adequados para execução.
 
+- ***URL_INTERESSES***: URL para planilha com lista de interesses analisados pelo Leggo. Consulte um membro da equipe para obter essa URL. 
+Exemplo: URL_INTERESSES="<url_para_planilha>"
+
 - ***PLS_FILEPATH***: caminho para o arquivo csv com a lista de Proposições que irão ter seus dados capturados e processados. Esse caminho é referenciado dentro do container rmod e por este motivo geralmente está ligado ao diretório `leggo_data`. 
-Exemplo: PLS_FILEPATH=./leggo_data/tabela_geral_ids_casa_new.csv
+Exemplo: PLS_FILEPATH=./leggo_data/tabela_geral_ids_casa_new.csv ou PLS_FILEPATH=./leggo_data/pls_interesses.csv (caso você queira capturar todos os interesses).
 
 - ***WORKSPACE_FOLDERPATH***: caminho para a pasta base do workspace (onde os repositórios estão clonados). Esse é o diretório a partir do qual o script de update vai rodar os comandos.
 Exemplo: WORKSPACE_FOLDERPATH=../

--- a/update_leggo_data.sh
+++ b/update_leggo_data.sh
@@ -237,6 +237,16 @@ setup_leggo_data_volume() {
         $EXPORT_FOLDERPATH/senado/parlamentares.csv
 }
 
+processa_pls_interesse() {
+
+pprint "Junta PL's de todos os interesses"
+docker-compose -f $LEGGOR_FOLDERPATH/docker-compose.yml run --rm rmod \
+       Rscript scripts/interesses/export_pls_leggo.R \
+       -u $URL_INTERESSES \
+       -e $EXPORT_FOLDERPATH/pls_interesses.csv
+
+}
+
 run_pipeline_leggo_content() {
        #Build container with current codebase
        build_versoes_props
@@ -260,8 +270,10 @@ run_full_pipeline() {
        #Setup volume of leggo data
        setup_leggo_data_volume
 
+       processa_pls_interesse
+
 	#Fetch and Process Prop metadata and tramitação
-	fetch_leggo_props
+       fetch_leggo_props
 
 	#Fetch Prop emendas
 	fetch_leggo_emendas


### PR DESCRIPTION
## Mudanças
- Adiciona passo ao pipeline que executa script do módulo R que junta todas as PL's de interesse do leggo para análise. Esse csv gerado é o que servirá de entrada para o restante do pipeline.
- Adiciona variável de ambiente com a URL para a planilha de gerenciamento para os links de interesse do Leggo. 

## Flags
- O script a ser executado no módulo R está presente na branch 1703-tabela-geral ou no PR https://github.com/parlametria/leggoR/pull/529
- Como são muitas proposições, executar o pipeline pode demorar bastante.
- A chave da URL para a planilha de gerenciamento pode ser obtida no link https://drive.google.com/open?id=1vbM2a_FgWRGTxlgvga1xPlqCMGFko42ywXjQpye2P2c (acesso restrito a membros)