### PR TITLE
Adiciona passo para mapeamento entre proposições processadas e Interesses

### DIFF
--- a/update_leggo_data.sh
+++ b/update_leggo_data.sh
@@ -247,6 +247,17 @@ docker-compose -f $LEGGOR_FOLDERPATH/docker-compose.yml run --rm rmod \
 
 }
 
+processa_interesses() {
+
+pprint "Processa o mapeamento de pls e interesses"
+docker-compose -f $LEGGOR_FOLDERPATH/docker-compose.yml run --rm rmod \
+       Rscript scripts/interesses/export_mapeamento_interesses.R \
+       -u $URL_INTERESSES \
+       -p $EXPORT_FOLDERPATH/proposicoes.csv \
+       -e $EXPORT_FOLDERPATH/interesses.csv
+
+}
+
 run_pipeline_leggo_content() {
        #Build container with current codebase
        build_versoes_props
@@ -274,6 +285,8 @@ run_full_pipeline() {
 
 	#Fetch and Process Prop metadata and tramitação
        fetch_leggo_props
+
+       processa_interesses
 
 	#Fetch Prop emendas
 	fetch_leggo_emendas


### PR DESCRIPTION
## Mudanças
- Adiciona passo que mapeia proposições processadas pelo leggo e interesses.

## Flags
- Assume que o PR https://github.com/parlametria/leggo-geral/pull/9 foi revisado e aprovado
- A tabela gerada tem o cabeçalho: id_leggo, interesse
- Executa com a versão do leggoR presente em https://github.com/parlametria/leggoR/pull/530
- URL de interesses para teste: https://docs.google.com/spreadsheets/d/e/2PACX-1vTOdLk1wxJsekjGF5alyD0AP25wVtpnq0QTy6IZTebY_WSiiAF6Any-_BWRTpcerTHHW4zJL3Y9hHpf/pub?gid=0&single=true&output=csv