### PR TITLE
US-1678-1725 - Reformula Pipeline de Análise de Emendas

### DIFF
--- a/update_leggo_data.sh
+++ b/update_leggo_data.sh
@@ -269,11 +269,7 @@ docker-compose -f $LEGGOR_FOLDERPATH/docker-compose.yml run --rm rmod \
 
 run_pipeline_leggo_content() {
        #Build container with current codebase
-       build_versoes_props
        build_leggo_content
-
-       #Fetch text
-       fetch_versoes_props
 
        # Analyze text
        process_leggo_content

--- a/update_leggo_data.sh
+++ b/update_leggo_data.sh
@@ -124,7 +124,7 @@ docker-compose -f $LEGGOR_FOLDERPATH/docker-compose.yml run --rm rmod \
         Rscript scripts/update_emendas_dist.R \
         $EXPORT_FOLDERPATH/raw_emendas_distances \
         $EXPORT_FOLDERPATH/distancias \
-        $EXPORT_FOLDERPATH/emendas_raw.csv \
+        $EXPORT_FOLDERPATH/novas_emendas.csv \
         $EXPORT_FOLDERPATH/emendas.csv
 check_errs $? "Não foi possível atualizar as distâncias advindas da análise de emendas."
 

--- a/update_leggo_data.sh
+++ b/update_leggo_data.sh
@@ -309,9 +309,6 @@ run_pipeline() {
 
        processa_interesses
 
-	#Fetch Prop emendas
-	fetch_leggo_emendas
-
 	#Compute Pressão
        fetch_leggo_trends
 


### PR DESCRIPTION
## Mudanças
- Adequa chamada de funções/scripts do leggoR ao novo pipeline de análise de emendas
- Remove chamadas ao container do versoes-props e à função fetch_emendas, que não são mais necessários

## Como Testar
- Deve ser avaliado (especialmente merjado) em conjunto com os PRs correspondentes nos outros repositórios: [leggo-content](https://github.com/parlametria/leggo-content/pull/20), [leggoR](https://github.com/parlametria/leggoR/pull/535) e [rcongresso](https://github.com/analytics-ufcg/rcongresso/pull/179)
- Para testar todos os PRs descritos acima (inclusive esse), deve-se:
  * Rodar o script update_data no leggo-geral
`./update_leggo_data.sh -update-data`
  * Verificar se há linhas do arquivo senado/documentos.csv cujo campo descricao_tipo_texto seja Avulso Inicial da Matéria. Para tanto, deve-se entrar no volume, podendo-se utilizar o docker do leggoR com o comando bash (rodando de dentro da pasta do leggoR):
`docker-compose run --rm rmod bash`
  * Rodar o script process_data no leggo-geral
`./update_leggo_data.sh -process-data`
  * Verificar a criação dos arquivos emendas_raw.csv, novas_emendas.csv, avulsos_iniciais.csv e avulsos_iniciais_novas_emendas.csv como saída. Tais arquivos devem conter as colunas de indexação (id_ext, codigo_emenda/codigo_texto, casa). Além disso, deve-se checar se novas_emendas.csv é um subconjunto de emendas_raw.csv, e avulsos_iniciais_novas_emendas.csv é um subconjunto de avulsos_iniciais.csv; e se avulsos_iniciais_novas_emendas.csv contém apenas os avulsos iniciais das proposições às quais as emendas em novas_emendas.csv pertencem.
  * Para simplificar e agilizar o teste, é interessante escolher uma proposição da Câmara e uma do Senado e rodar a análise de emendas apenas para elas. Para fazer isso, deve-se editar os arquivos novas_emendas.csv e avulsos_iniciais_novas_emendas.csv, deixando apenas a emendas e os avulsos iniciais das proposições escolhidas, respectivamente. Em testes subsequentes, pode rodar direto sem essa filtragem para testar para mais proposições, mas esse subset já deve ser suficiente para testar todo o pipeline.
  * Rodar o pipeline de análise de emendas no leggo-geral
`./update_leggo_data.sh -run-pipeline-leggo-content`
  * Verificar se os passos do pipeline rodaram sem erro (observar o log em /tmp/update_leggo_data.log).
  * Verificar se as emendas contidas em novas_emendas.csv foram adicionadas a emendas.csv com suas respectivas distâncias (quando não foi possível calcular, deve aparecer a distância -1).