### PR TITLE
Separa arquivos de logs 

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,6 @@ LEGGOR_FOLDERPATH=./leggoR
 LEGGOTRENDS_FOLDERPATH=./leggoTrends
 VERSOESPROPS_FOLDERPATH=./versoes-de-proposicoes
 LEGGOCONTENT_FOLDERPATH=./leggo-content
-LOG_FILEPATH=/tmp/update_leggo_data.log
+LOG_FOLDERPATH=/tmp/logs_leggo_updater/
 PROD_BACK_APP=production_app_name
 DEV_BACK_APP=production_app_name

--- a/update_leggo_data.sh
+++ b/update_leggo_data.sh
@@ -6,9 +6,16 @@ source .env
 # Adiciona possiveis caminhos de bibliotecas ao PATH
 PATH=$PATH:/usr/local/bin
 
+# Cria o diretório destino dos logs deste script
+mkdir -p $LOG_FOLDERPATH
+
+# Gera o nome do arquivo do log a partir do timestamp 
+timestamp=$(date '+%d_%m_%Y_%H_%M_%S');
+log_filepath="${LOG_FOLDERPATH}${timestamp}.txt"
+
 # Faz com que as mensagens comumns e de erro deste script apareçam tanto no
 # terminal como em um arquivo de log
-exec > >(tee -a $LOG_FILEPATH) 2>&1
+exec > >(tee -a $log_filepath) 2>&1
 
 # Pretty Print
 pprint() {


### PR DESCRIPTION
**Mudanças propostas neste PR:**
  - Separa os logs do script `updater_leggo_data.sh`: Cada execução do script será salva em um arquivo separado e nomeado pelo timestamp de início da execução; 
  - Atualiza variável de ambiente de destino dos logs: Antes um arquivo único, foi modificada para ser um diretório.