### PR TITLE
Modifica chamada ao script que exporta insights

### DIFF
--- a/update_leggo_data.sh
+++ b/update_leggo_data.sh
@@ -344,7 +344,7 @@ docker-compose -f $LEGGOR_FOLDERPATH/docker-compose.yml run --rm rmod \
        -u $URL_LISTA_ANOTACOES \
        -i $EXPORT_FOLDERPATH/pls_interesses.csv \
        -p $EXPORT_FOLDERPATH/proposicoes.csv \
-       -e $EXPORT_FOLDERPATH/anotacoes.csv
+       -e $EXPORT_FOLDERPATH
 }
 
 run_pipeline_leggo_content() {


### PR DESCRIPTION
**Modificações neste PR**:
- Altera a chamada ao script `export_anotacoes.R`, modificando o argumento que recebia o arquivo destino para o caminho do diretório que conterá os dois novos arquivos de insights.

**OBS:** Para executar o script é necessário estar na branch `adiciona-insights-gerais` do [leggoR](https://github.com/parlametria/leggoR/tree/adiciona-insights-gerais).