### PR TITLE
Altera chamadas de scripts do leggoTrends

### DIFF
--- a/update_leggo_data.sh
+++ b/update_leggo_data.sh
@@ -295,13 +295,13 @@ docker-compose -f $LEGGOTRENDS_FOLDERPATH/docker-compose.yml run --rm leggo-tren
        configuration.env
 check_errs $? "Não foi possível baixar dados de pressão pelo Google Trends."
 
-pprint "Gerando dados de popularidade do Twitter"
-docker-compose -f $LEGGOTRENDS_FOLDERPATH/docker-compose.yml \
-      run --rm leggo-trends \
-      Rscript scripts/tweets_from_last_days/export_tweets_from_last_days.R \
-      -a leggo_data/apelidos.csv \
-      -o leggo_data/ 
-check_errs $? "Não foi possível baixar dados de pressão pelo Twitter."
+# pprint "Gerando dados de popularidade do Twitter"
+# docker-compose -f $LEGGOTRENDS_FOLDERPATH/docker-compose.yml \
+#       run --rm leggo-trends \
+#       Rscript scripts/tweets_from_last_days/export_tweets_from_last_days.R \
+#       -a leggo_data/apelidos.csv \
+#       -o leggo_data/ 
+# check_errs $? "Não foi possível baixar dados de pressão pelo Twitter."
 
 pprint "Gerando índice de popularidade combinando Twitter e Google Trends"
 docker-compose -f $LEGGOTRENDS_FOLDERPATH/docker-compose.yml run --rm leggo-trends \

--- a/update_leggo_data.sh
+++ b/update_leggo_data.sh
@@ -307,7 +307,7 @@ pprint "Gerando índice de popularidade combinando Twitter e Google Trends"
 docker-compose -f $LEGGOTRENDS_FOLDERPATH/docker-compose.yml run --rm leggo-trends \
       Rscript scripts/popularity/export_popularity.R \
       -t leggo_data/trends.csv \
-      -g leggo_data/pops/ \
+      -g leggo_data/pops \
       -i leggo_data/interesses.csv \
       -o leggo_data/pressao.csv
 check_errs $? "Não foi possível combinar os dados de pressão do Twitter e Google Trends."

--- a/update_leggo_data.sh
+++ b/update_leggo_data.sh
@@ -283,7 +283,6 @@ pprint "Gerando dataframe com os apelidos para busca no Twitter e Google Trends"
 docker-compose -f $LEGGOTRENDS_FOLDERPATH/docker-compose.yml run --rm leggo-trends \
        Rscript gera_entrada_google_trends.R \
        -p leggo_data/proposicoes.csv \
-       -i leggo_data/interesses.csv \
        -a leggo_data/apelidos.csv 
 check_errs $? "Não foi possível gerar os dados de apelidos das proposições."
 
@@ -309,6 +308,7 @@ docker-compose -f $LEGGOTRENDS_FOLDERPATH/docker-compose.yml run --rm leggo-tren
       Rscript scripts/popularity/export_popularity.R \
       -t leggo_data/trends.csv \
       -g leggo_data/pops/ \
+      -i leggo_data/interesses.csv \
       -o leggo_data/pressao.csv
 check_errs $? "Não foi possível combinar os dados de pressão do Twitter e Google Trends."
 


### PR DESCRIPTION
### Mudanças

- Retira argumento de interesses na geração dos apelidos e adiciona no script que processa os dados de pressao.csv;
- Retira barra final do caminho onde as pressões do google trends estão salvas.

**OBS:** É necessário estar com o trends atualizado na versão deste [PR](https://github.com/parlametria/leggoTrends/pull/38).